### PR TITLE
impossible handling for necessary_executable query

### DIFF
--- a/logic.pl
+++ b/logic.pl
@@ -7,10 +7,10 @@
 after(Result, []):-
 	initially(Result).
 
-impossible_by_if(Action, Group, []):-
+impossible_by_if(Action, Group, _):-
 	impossible_by(Action, Group), !.
 	
-impossible_by_if(Action, [], State):-
+impossible_by_if(Action, _, State):-
 	impossible_if(Action, State), !.
 
 
@@ -31,6 +31,7 @@ by_causes_if(Action, [], Result, State):-
 necessary_executable_from([[Action, Group] | Program], CurrentStates):-
 	by_causes_if(Action, Group, ResultingState, X),
 	subset(X, CurrentStates),
+	not(impossible_by_if(Action, Group, X)),
 	delete(CurrentStates, ResultingState, ListWithoutResultingState),
 	delete(ListWithoutResultingState, \ResultingState, ListWithoutNotResultingState),
 	append(ListWithoutNotResultingState, [ResultingState], NewCurrentStates),

--- a/tests/necessary_executable/model.pl
+++ b/tests/necessary_executable/model.pl
@@ -22,3 +22,9 @@ by_causes_if(action4, [g3, g4], other, [alpha, beta]).
 % Test case 4 - action6 impossible, because we never achieve delta
 by_causes_if(action5, [g5, g6], delta, [psi]).
 by_causes_if(action6, [g5, g6], result3, [delta, gamma]).
+
+% Test case 5 a. - action_5_1 impossible by g_5_1
+% Test case 5 b. - action_5_1 possible by g_5_2
+impossible_by(action_5_1, [g_5_1]).
+by_causes_if(action_5_1, [g_5_1], delta_5,[psi_5]).
+by_causes_if(action_5_1, [g_5_2], delta_5,[psi_5]).

--- a/tests/necessary_executable/test.pl
+++ b/tests/necessary_executable/test.pl
@@ -45,6 +45,13 @@ write('Test case 4 - action6 impossible, because we never achieve delta\n'),
 (write('not(necessary_executable_from([[action5,[g5, g6]],[action6,[g5, g6]]], [psi])). => '),
 not(necessary_executable_from([[action5,[g5, g6]],[action6,[g5, g6]]], [psi])), nl, passed; failed), nl,
 
+write('Test case 5 a. - action_5_1 impossible by g_5_1\n'),
+(write('not(necessary_executable_from([[action_5_1,[g_5_1]]],[psi_5])). => '),
+not(necessary_executable_from([[action_5_1,[g_5_1]]],[psi_5])), nl, passed; failed), nl,
+
+write('Test case 5 b. - action_5_1 possible by g_5_2\n'),
+(write('necessary_executable_from([[action_5_1,[g_5_2]]],[psi_5]). => '),
+necessary_executable_from([[action_5_1,[g_5_2]]],[psi_5]), nl, passed; failed), nl,
 
 
 write('Necessary Executable - TESTS FINISHED'),nl.


### PR DESCRIPTION
Wydaje mi się, że jak parametr ma być pusty to powinniśmy go oznaczyć jako _ zamiast [], ale z moją wiedzą z prologa mogę się mylić. Po zamianie na _ zaczeło działać